### PR TITLE
Add enemy combat and player health UI

### DIFF
--- a/scenes/Enemy.tscn
+++ b/scenes/Enemy.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=6 format=3 uid="uid://enemy"]
+[gd_scene load_steps=10 format=3 uid="uid://enemy"]
 
 [ext_resource type="Script" uid="uid://do3js3av83rl" path="res://scripts/enemy_patrol.gd" id="1"]
 [ext_resource type="Script" uid="uid://qklqddbokb75" path="res://scripts/health.gd" id="2"]
+[ext_resource type="Script" uid="uid://da4c5qp6ejrhc" path="res://scripts/hitbox.gd" id="3"]
+[ext_resource type="Script" uid="uid://dgi6avek8ewgc" path="res://scripts/hurtbox.gd" id="4"]
 
 [sub_resource type="RectangleShape2D" id="1"]
 size = Vector2(20, 16)
@@ -13,6 +15,12 @@ colors = PackedColorArray(1, 0.4, 0.4, 1, 0.7, 0.2, 0.2, 1)
 gradient = SubResource("2")
 width = 20
 height = 16
+
+[sub_resource type="RectangleShape2D" id="4"]
+size = Vector2(20, 16)
+
+[sub_resource type="RectangleShape2D" id="5"]
+size = Vector2(20, 16)
 
 [node name="Enemy" type="CharacterBody2D"]
 script = ExtResource("1")
@@ -26,6 +34,18 @@ texture = SubResource("3")
 
 [node name="Health" type="Node" parent="."]
 script = ExtResource("2")
+
+[node name="Hitbox" type="Area2D" parent="."]
+script = ExtResource("3")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Hitbox"]
+shape = SubResource("4")
+
+[node name="Hurtbox" type="Area2D" parent="."]
+script = ExtResource("4")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Hurtbox"]
+shape = SubResource("5")
 
 [node name="P1" type="Marker2D" parent="."]
 position = Vector2(-80, 0)

--- a/scenes/HealthBar.tscn
+++ b/scenes/HealthBar.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=3 uid="uid://healthbar"]
+
+[ext_resource type="Script" uid="uid://healthbarscript" path="res://scripts/health_bar.gd" id="1"]
+
+[node name="HealthBar" type="CanvasLayer"]
+script = ExtResource("1")
+
+[node name="Bar" type="ProgressBar" parent="."]
+offset_left = 8.0
+offset_top = 8.0
+offset_right = 108.0
+offset_bottom = 24.0
+max_value = 3.0
+value = 3.0

--- a/scenes/World.tscn
+++ b/scenes/World.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=9 format=3 uid="uid://world"]
+[gd_scene load_steps=10 format=3 uid="uid://world"]
 
 [ext_resource type="PackedScene" uid="uid://player" path="res://scenes/Player.tscn" id="1"]
 [ext_resource type="PackedScene" uid="uid://enemy" path="res://scenes/Enemy.tscn" id="2"]
 [ext_resource type="PackedScene" uid="uid://checkpoint" path="res://scenes/Checkpoint.tscn" id="3"]
+[ext_resource type="PackedScene" uid="uid://healthbar" path="res://scenes/HealthBar.tscn" id="4"]
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_7g83o"]
 
@@ -65,3 +66,6 @@ position = Vector2(80, 0)
 
 [node name="Checkpoint" parent="." instance=ExtResource("3")]
 position = Vector2(220, 20)
+
+[node name="HealthBar" parent="." instance=ExtResource("4")]
+health_path = NodePath("../Player/Health")

--- a/scripts/enemy_patrol.gd
+++ b/scripts/enemy_patrol.gd
@@ -10,32 +10,43 @@ var _targets: Array[Vector2] = []
 var _gravity: float = 1800.0
 
 @onready var health: Health = $Health
+@onready var hitbox: Area2D = $Hitbox
+@onready var hurtbox: Area2D = $Hurtbox
 
 func _ready() -> void:
-	for p in patrol_points:
-		var n = get_node_or_null(p)
-		if n:
-			_targets.append(n.global_position)
-	health.connect("died", Callable(self, "_on_died"))
+        for p in patrol_points:
+                var n = get_node_or_null(p)
+                if n:
+                        _targets.append(n.global_position)
+        health.connect("died", Callable(self, "_on_died"))
+        hurtbox.connect("hurt", Callable(self, "_on_hurt"))
+        hitbox.damage = contact_damage
 
 func _physics_process(delta: float) -> void:
-	if _targets.size() >= 1:
-		var target = _targets[_target_index]
-		var dir = sign(target.x - global_position.x)
-		velocity.x = dir * speed
-		if abs(target.x - global_position.x) < 4.0:
-			_target_index = (_target_index + 1) % _targets.size()
+        if _targets.size() >= 1:
+                var target = _targets[_target_index]
+                var dir = sign(target.x - global_position.x)
+                velocity.x = dir * speed
+                if abs(target.x - global_position.x) < 4.0:
+                        _target_index = (_target_index + 1) % _targets.size()
 
-	if not is_on_floor():
-		velocity.y += _gravity * delta
-	else:
-		velocity.y = 0.0
+        if not is_on_floor():
+                velocity.y += _gravity * delta
+        else:
+                velocity.y = 0.0
 
-	move_and_slide()
+        var player = get_tree().get_first_node_in_group("player")
+        if player:
+                hitbox.owner_facing_right = player.global_position.x > global_position.x
+
+        move_and_slide()
 
 func apply_damage(amount: int, kb: Vector2) -> void:
-	health.damage(amount)
-	velocity = kb
+        health.damage(amount)
+        velocity = kb
+
+func _on_hurt(damage: int, from_vec: Vector2) -> void:
+        apply_damage(damage, from_vec)
 
 func _on_died() -> void:
-	queue_free()
+        queue_free()

--- a/scripts/health_bar.gd
+++ b/scripts/health_bar.gd
@@ -1,0 +1,18 @@
+extends CanvasLayer
+
+@export var health_path: NodePath
+
+@onready var bar: ProgressBar = $Bar
+var health: Health
+
+func _ready() -> void:
+    if health_path != NodePath(""):
+        health = get_node(health_path)
+        if health:
+            bar.max_value = health.max_health
+            bar.value = health.current
+            health.connect("health_changed", Callable(self, "_on_health_changed"))
+
+func _on_health_changed(current: int, max_val: int) -> void:
+    bar.max_value = max_val
+    bar.value = current

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -41,10 +41,11 @@ var _dash_cd: float = 0.0
 var _attack_t: float = 0.0
 
 func _ready() -> void:
-	health.connect("died", Callable(self, "_on_died"))
-	hurtbox.connect("hurt", Callable(self, "_on_hurt"))
-	hitbox.monitoring = false
-	hitbox_shape.disabled = true
+        add_to_group("player")
+        health.connect("died", Callable(self, "_on_died"))
+        hurtbox.connect("hurt", Callable(self, "_on_hurt"))
+        hitbox.monitoring = false
+        hitbox_shape.disabled = true
 
 func _physics_process(delta: float) -> void:
 	_coyote = max(0.0, _coyote - delta)


### PR DESCRIPTION
## Summary
- Enable enemies to react to attacks and deal contact damage
- Track player health with a simple UI progress bar

## Testing
- ⚠️ `godot --headless --check-only` *(command not found)*
- ⚠️ `apt-get install -y godot4` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdde52de04832c8eb4af7aa3d2050f