### PR TITLE
Fix attack and health system with chase AI

### DIFF
--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://player"]
+[gd_scene load_steps=12 format=3 uid="uid://player"]
 
 [ext_resource type="Script" uid="uid://ps6q2mp0g44q" path="res://scripts/player.gd" id="1"]
 [ext_resource type="Script" uid="uid://da4c5qp6ejrhc" path="res://scripts/hitbox.gd" id="2"]
@@ -21,6 +21,14 @@ size = Vector2(20, 12)
 
 [sub_resource type="RectangleShape2D" id="5"]
 size = Vector2(16, 20)
+
+[sub_resource type="Gradient" id="6"]
+colors = PackedColorArray(1, 0, 0, 1, 0.8, 0, 0, 1)
+
+[sub_resource type="GradientTexture2D" id="7"]
+gradient = SubResource("6")
+width = 20
+height = 20
 
 [node name="Player" type="CharacterBody2D"]
 script = ExtResource("1")
@@ -45,6 +53,10 @@ script = ExtResource("2")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hitbox"]
 position = Vector2(16, 0)
 shape = SubResource("4")
+
+[node name="AttackSprite" type="Sprite2D" parent="Hitbox"]
+visible = false
+texture = SubResource("7")
 
 [node name="Hurtbox" type="Area2D" parent="."]
 script = ExtResource("3")

--- a/scripts/enemy_patrol.gd
+++ b/scripts/enemy_patrol.gd
@@ -2,11 +2,7 @@
 extends CharacterBody2D
 
 @export var speed: float = 90.0
-@export var patrol_points: Array[NodePath] = []
 @export var contact_damage: int = 1
-
-var _target_index := 0
-var _targets: Array[Vector2] = []
 var _gravity: float = 1800.0
 
 @onready var health: Health = $Health
@@ -14,30 +10,23 @@ var _gravity: float = 1800.0
 @onready var hurtbox: Area2D = $Hurtbox
 
 func _ready() -> void:
-        for p in patrol_points:
-                var n = get_node_or_null(p)
-                if n:
-                        _targets.append(n.global_position)
         health.connect("died", Callable(self, "_on_died"))
         hurtbox.connect("hurt", Callable(self, "_on_hurt"))
         hitbox.damage = contact_damage
 
 func _physics_process(delta: float) -> void:
-        if _targets.size() >= 1:
-                var target = _targets[_target_index]
-                var dir = sign(target.x - global_position.x)
+        var player = get_tree().get_first_node_in_group("player")
+        if player:
+                var dir = sign(player.global_position.x - global_position.x)
                 velocity.x = dir * speed
-                if abs(target.x - global_position.x) < 4.0:
-                        _target_index = (_target_index + 1) % _targets.size()
+                hitbox.owner_facing_right = dir >= 0
+        else:
+                velocity.x = 0.0
 
         if not is_on_floor():
                 velocity.y += _gravity * delta
         else:
                 velocity.y = 0.0
-
-        var player = get_tree().get_first_node_in_group("player")
-        if player:
-                hitbox.owner_facing_right = player.global_position.x > global_position.x
 
         move_and_slide()
 

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -30,6 +30,7 @@ enum State { NORMAL, DASHING, ATTACKING, HURT, DEAD }
 @onready var hitbox_shape: CollisionShape2D = $Hitbox/CollisionShape2D
 @onready var hurtbox: Area2D = $Hurtbox
 @onready var health: Health = $Health
+@onready var attack_sprite: Sprite2D = $Hitbox/AttackSprite
 
 var state: State = State.NORMAL
 var facing_right := true
@@ -153,14 +154,18 @@ func _input(event: InputEvent) -> void:
 
 func _begin_attack_window() -> void:
 	hitbox.monitoring = true
+	hitbox.monitorable = true
 	hitbox_shape.disabled = false
 	hitbox.position.x = 16.0 * (1 if facing_right else -1)
 	hitbox.position.y = 0.0
 	hitbox.owner_facing_right = facing_right
+	attack_sprite.visible = true
 
 func _end_attack_window() -> void:
 	hitbox.monitoring = false
+	hitbox.monitorable = false
 	hitbox_shape.disabled = true
+	attack_sprite.visible = false
 
 func apply_damage(amount: int, kb: Vector2) -> void:
 	if state == State.DEAD:


### PR DESCRIPTION
## Summary
- Enable hitbox monitoring and show a simple attack sprite
- Make enemy chase the player and respect knockback direction

## Testing
- `godot3 --path . --no-window --quit` *(fails: project requires newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_68bde2775b2c832c8754e7677d5c7778